### PR TITLE
Build on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ target/
 # Operating System Files
 # =========================
 
-# OSX
+# macOS
 # =========================
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -38,11 +38,8 @@ For anyone using these tools to assemble their own pack:
   set up and configured via these files, which are also commented.
 
 - You will need Python 3.5+, as I make extensive use of several
-  new features.  You will also need the `requests` and `pyaml`
-  libraries (both can be installed with `pip`).
-
-  Optional dependencies to unpack exotic archive types may be
-  added in future, but will not be required.
+  new features.  Dependencies can be installed with
+  `pip install -r requirements.txt`.
 
 - Many items in the provided config will only work on Windows
   (or when building for windows on another OS; tested on Debian).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See the [hourly build log here](http://peridexiserrant.neocities.org/starter-pac
 There is *no support* for using this tool - it is designed for my own use,
 and released in the hope that others might find it useful.
 Bug reports are most welcome; feature requests are not
-(missing OS support is considered a bug - it should work on Windows, OSX, and Linux).
+(missing OS support is considered a bug - it should work on Windows, macOS, and Linux).
 
 **What it does:**
 
@@ -46,7 +46,7 @@ For anyone using these tools to assemble their own pack:
 
 - Many items in the provided config will only work on Windows
   (or when building for windows on another OS; tested on Debian).
-  If you are interested in helping support OSX or Linux, please
+  If you are interested in helping support macOS or Linux, please
   get in touch with my handle at gmail.
 
 

--- a/components.yml
+++ b/components.yml
@@ -144,6 +144,7 @@ utilities:
         manifest:
             tooltip: A Sound+Music engine for DF - it reads the gamelog, and plays appropriate sounds and seasonal music.
             linux_exe: soundSense.sh
+            osx_exe: soundSense.sh
     World Viewer:
         requires_os: win
         bay12: 128932

--- a/components.yml
+++ b/components.yml
@@ -63,6 +63,7 @@ files:
         install_after: Quickfort
 utilities:
     Armok Vision:
+        requires_os: win linux
         bay12: 146473
         ident: JapaMala/armok-vision
         needs_dfhack: True

--- a/components.yml
+++ b/components.yml
@@ -26,6 +26,9 @@ files:
         os-linux:
             extract_to: |
                 PyLNP:build/starter-pack-launcher
+        os-osx:
+            extract_to: |
+                PyLNP.app:build/Starter Pack Launcher (PyLNP).app
     Stocksettings presets:
         bay12: 146213
         ident: 10170
@@ -43,6 +46,9 @@ files:
             extract_to: |
                 {DFHACK_VER}/mousequery.plug.so:plugins/
                 {DFHACK_VER}/twbt.plug.so:plugins/
+        os-osx:
+            extract_to: |
+                {DFHACK_VER}/twbt.plug.dylib:plugins/
         needs_dfhack: True
         install_after: DFHack
     Quickfort_64:

--- a/components.yml
+++ b/components.yml
@@ -108,6 +108,7 @@ utilities:
         ident: robertjanetzko/LegendsBrowser
         manifest:
             tooltip: An in-browser legends utility, available for all operating systems.
+            osx_exe: Legends Browser.app/Contents/MacOS/JavaAppLauncher
     Legends Viewer:
         requires_os: win
         bay12: 154617

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyyaml==3.12
+pyyaml==3.13
 rarfile==3.0
 requests==2.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml==3.12
+requests==2.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml==3.12
+rarfile==3.0
 requests==2.19.1

--- a/starterpack/build.py
+++ b/starterpack/build.py
@@ -237,7 +237,8 @@ def create_utilities():
         if paths.HOST_OS != 'win':
             with open(paths.utilities(util.name, 'manifest.json')) as f:
                 exe = json.load(f)[paths.HOST_OS + '_exe']
-            os.chmod(exe, 0o110 | os.stat(exe).st_mode)
+            path = paths.utilities(util.name, exe)
+            os.chmod(path, 0o110 | os.stat(path).st_mode)
 
 
 # Configure graphics packs

--- a/starterpack/build.py
+++ b/starterpack/build.py
@@ -191,12 +191,12 @@ def _therapist_ini():
 
 
 def _exes_for(util):
-    """Find the best available match for Windows and OSX utilities."""
+    """Find the best available match for Windows and macOS utilities."""
     win_exe, osx_exe, linux_exe = '', '', ''
     for _, dirs, files in os.walk(paths.utilities(util.name)):
         # Windows: first .exe found, first .bat otherwise
         # Linux: first .jar found, otherwise .sh
-        # OSX: as for linux, but a .app directory wins
+        # macOS: as for linux, but a .app directory wins
         for f in files:
             if win_exe and osx_exe and linux_exe:
                 break

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -64,7 +64,7 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
 
     Involves a lot of shelling out, as Python's `tarfile` cannot open
     the .tar.bz2 archived DF releases (complicated header issue).
-    OSX disk images (.dmg) are also unsupported by Python.
+    macOS disk images (.dmg) are also unsupported by Python.
     """
     if filename.endswith('.exe') and paths.HOST_OS == 'win' \
             or filename.endswith('.jar'):
@@ -96,7 +96,7 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
 def unpack_anything(filename, tmpdir):
     """Extract practically any archive format from src file to dest dir."""
     if filename.endswith('.dmg') and paths.HOST_OS == 'osx':
-        # TODO:  support .dmg extraction via shell on OSX
+        # TODO:  support .dmg extraction via shell on macOS
         raise NotImplementedError(
             'TODO: mount .dmg, copy contents to tmpdir, unmount')
     elif zipfile.is_zipfile(filename):

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -169,6 +169,10 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
         files = [os.path.join(root, f)
                  for root, _, files in os.walk(tmpdir) for f in files]
         prefix = os.path.commonpath(files) if len(files) > 1 else ''
+        # BAD HACK: It's an unsafe assumption (made above) that the common
+        # path should always be stripped.
+        if filename.endswith('.dmg') and 'Legends Browser' in target_dir:
+            prefix = ''
         if target_dir:
             copy_tree(os.path.join(tmpdir, prefix), target_dir,
                       preserve_symlinks=True)
@@ -246,7 +250,6 @@ def unpack_anything(filename, tmpdir):
 
 def extract_comp(comp):
     """Extracts a single component."""
-    print('Extracting', comp.name)
     if ':' not in comp.extract_to:
         # first part of extract_to is paths method, remainder is args
         dest, *details = comp.extract_to.split('/')

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -4,7 +4,6 @@ This module is about as generic as it can usefully be, pushing the special
 cases back into build.py
 """
 
-import concurrent.futures
 from distutils.dir_util import copy_tree
 import os
 import shutil
@@ -17,6 +16,43 @@ import zipfile
 
 from . import component
 from . import paths
+
+
+class TaskQueue:
+    def __init__(self):
+        self.tasks = {}
+
+    def add(self, name, prereqs=None):
+        self.tasks[name] = (prereqs or [])
+
+    def pop(self):
+        for name, prereqs in self.tasks.items():
+            if len(prereqs) == 0:
+                self.remove(name)
+                return name
+        # Nothing found with no pending prerequisites; maybe there's a circular
+        # reference?
+        if len(self.tasks) == 0:
+            raise IndexError('pop from empty queue')
+        raise RuntimeError('circular dependencies detected')
+
+    def remove(self, name):
+        del self.tasks[name]
+        for prereqs in self.tasks.values():
+            try:
+                prereqs.remove(name)
+            except ValueError:
+                continue
+    
+    def __iter__(self):
+        """Allows iterating over queued tasks, which empties the queue."""
+        return self
+    
+    def __next__(self):
+        try:
+            return self.pop()
+        except IndexError:
+            raise StopIteration
 
 
 class UnixAwareZipFile(zipfile.ZipFile):
@@ -54,7 +90,7 @@ def _copyfile(src, dest, zipinfo=None):
         if os.path.isfile(src):
             shutil.copy2(src, dest)
         elif os.path.isdir(src):
-            copy_tree(src, dest)
+            copy_tree(src, dest, preserve_symlinks=True)
         else:
             raise IOError('Unexpected file type for %s', src)
     elif isinstance(src, zipfile.ZipExtFile):
@@ -81,6 +117,7 @@ def unzip_to(filename, target_dir=None, path_pairs=None):
     In 'path_pairs' mode, the argument should be a sequence of paths.
     The file at the first path within the zip is written at the second path.
     """
+    print('unzip_to', filename, target_dir, path_pairs)
     assert bool(target_dir) != bool(path_pairs), 'Choose one unzip mode!'
     out = target_dir or os.path.commonpath([p[1] for p in path_pairs])
     print('{:28}  ->  {}'.format(os.path.basename(filename)[:28],
@@ -123,7 +160,8 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
                  for root, _, files in os.walk(tmpdir) for f in files]
         prefix = os.path.commonpath(files) if len(files) > 1 else ''
         if target_dir:
-            copy_tree(os.path.join(tmpdir, prefix), target_dir)
+            copy_tree(os.path.join(tmpdir, prefix), target_dir,
+                      preserve_symlinks=True)
         else:
             for inpath, outpath in path_pairs:
                 if outpath.endswith('/'):
@@ -188,63 +226,33 @@ def unpack_anything(filename, tmpdir):
     return False
 
 
-def extract_comp(pool, comp):
-    """Return args with which comp can be sent to the executor."""
+def extract_comp(comp):
+    """Extracts a single component."""
+    print('Extracting', comp.name)
     if ':' not in comp.extract_to:
         # first part of extract_to is paths method, remainder is args
         dest, *details = comp.extract_to.split('/')
-        return pool.submit(unzip_to, comp.path, getattr(paths, dest)(*details))
+        return unzip_to(comp.path, target_dir=getattr(paths, dest)(*details))
     # else using the path_pairs option; extract pairs from string
     pairs = []
-    for pair in comp.extract_to.strip().split('\n'):
-        src, to = pair.split(':')
+    for pair in comp.extract_to.strip().splitlines():
+        src, _, to = pair.partition(':')
         dest, *details = to.split('/')
         # Note: can add format variables here as needed
         if '{DFHACK_VER}' in src:
             src = src.format(DFHACK_VER=component.ALL['DFHack'].version)
-        pairs.append([src, getattr(paths, dest)(*details)])
-    return pool.submit(unzip_to, comp.path, None, pairs)
+        pairs.append((src, getattr(paths, dest)(*details)))
+    return unzip_to(comp.path, path_pairs=pairs)
 
 
 def extract_everything():
-    """Extract everything in components.yml, respecting order requirements."""
-    def q_key(comp):
-        """Decide extract priority by pointer-chase depth, filesize in ties."""
-        after = {c.install_after: c.name for c in component.ALL.values()}
-        name, seen = comp.name, []
-        while name in after:
-            seen.append(name)
-            name = after.get(name)
-            if name in seen:
-                raise ValueError('Cyclic "install_after" config detected: ' +
-                                 ' -> '.join(seen + [name]))
-        return len(seen), os.path.getsize(comp.path)
-
-    queue = list(component.ALL.values()) + [
-        component.ALL['Dwarf Fortress']._replace(name=path, extract_to=path)
-        for path in ('curr_baseline', 'graphics/ASCII')]
-    queue.sort(key=q_key, reverse=True)
-    with concurrent.futures.ProcessPoolExecutor(8) as pool:
-        futures = dict()
-        while queue:
-            while sum(f.running() for f in futures.values()) < 8:
-                for idx, comp in enumerate(queue):
-                    aft = futures.get(comp.install_after)
-                    # Even if it's highest-priority, wait for parent job(s)
-                    if aft is None or aft.done():
-                        futures[comp.name] = extract_comp(pool, queue.pop(idx))
-                        break  # reset index or we might pop the wrong item
-                else:
-                    break  # if there was nothing eligible to extract, sleep
-            time.sleep(0.01)
-    failed = [k for k, v in futures.items() if v.exception() is not None]
-    for key in failed:
-        comp = component.ALL.pop(key, None)
-        for lst in (component.FILES, component.GRAPHICS, component.UTILITIES):
-            if comp in lst:
-                lst.remove(comp)
-    if failed:
-        print('ERROR:  Could not extract: ' + ', '.join(failed))
+    """Extract every component, respecting order requirements."""
+    queue = TaskQueue()
+    for comp in component.ALL.values():
+        after = [ comp.install_after ] if comp.install_after else []
+        queue.add(comp, prereqs=after)
+    for comp in queue:
+        extract_comp(comp)
 
 
 def add_lnp_dirs():

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -93,12 +93,21 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
     return True
 
 
+def unpack_dmg(filename, dest):
+    """Extract a .dmg disk image on macOS into the dest dir."""
+    assert filename.endswith('.dmg') and paths.HOST_OS == 'osx'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(['hdiutil', 'attach', '-quiet', '-readonly',
+                               '-nobrowse', '-mountpoint', tmpdir, filename])
+        copy_tree(tmpdir, dest)
+        subprocess.check_call(['hdiutil', 'detach', '-quiet', tmpdir])
+
+
 def unpack_anything(filename, tmpdir):
     """Extract practically any archive format from src file to dest dir."""
     if filename.endswith('.dmg') and paths.HOST_OS == 'osx':
-        # TODO:  support .dmg extraction via shell on macOS
-        raise NotImplementedError(
-            'TODO: mount .dmg, copy contents to tmpdir, unmount')
+        unpack_dmg(filename, tmpdir)
+        return True
     elif zipfile.is_zipfile(filename):
         # Uses fast version above; handled here for completeness
         zipfile.ZipFile(filename).extractall(tmpdir)

--- a/starterpack/metadata_api.py
+++ b/starterpack/metadata_api.py
@@ -26,7 +26,7 @@ def get_auth():
     return None
 
 
-def cache(method=lambda *_: None, *, saved={}, dump=False):
+def cache(method=lambda *_: None, *, saved={}, dump=False, expiration=30*60):
     """A caching decorator.
 
     Reads cache from local file if cache is empty.
@@ -37,10 +37,11 @@ def cache(method=lambda *_: None, *, saved={}, dump=False):
         try:
             with open('_cached.yml') as f:
                 saved.update(yaml.load(f))
+                print('Loaded metadata from cache file')
         except IOError:
-            print('Downloading metadata for components...\n')
             saved.update({'metadata': {}, 'timestamps': {}})
     elif dump:
+        print('Saving metadata to cache file')
         with open('_cached.yml', 'w') as f:
             yaml.dump(saved, f, indent=4)
 
@@ -50,11 +51,13 @@ def cache(method=lambda *_: None, *, saved={}, dump=False):
             key = (not paths.ARGS.stable, ident)
             args = (self, ident, saved['timestamps'].get(key, 0),
                     saved['metadata'].get(ident))
-        if (time.time() - saved['timestamps'].get(key, 0)) > 30*60:
+        if (time.time() - saved['timestamps'].get(key, 0)) > expiration:
+            print('Refreshing metadata for package', ident)
             new_json = method(*args)
+            # We take a return value of None to mean that it hasn't been updated
             if new_json is not None:
                 saved['metadata'][key] = new_json
-                saved['timestamps'][key] = time.time()
+            saved['timestamps'][key] = time.time()
         return saved['metadata'].get(key)
     return wrapper
 

--- a/starterpack/metadata_api.py
+++ b/starterpack/metadata_api.py
@@ -50,13 +50,13 @@ def cache(method=lambda *_: None, *, saved={}, dump=False, expiration=30*60):
         if isinstance(self, GitHubAssetMetadata):
             key = (not paths.ARGS.stable, ident)
             args = (self, ident, saved['timestamps'].get(key, 0),
-                    saved['metadata'].get(ident))
+                    saved['metadata'].get(key))
         if (time.time() - saved['timestamps'].get(key, 0)) > expiration:
             print('Refreshing metadata for package', ident)
             new_json = method(*args)
-            # We take a return value of None to mean that it hasn't been updated
-            if new_json is not None:
-                saved['metadata'][key] = new_json
+            if new_json is None:
+                raise RuntimeError('Failed to get metadata for', ident)
+            saved['metadata'][key] = new_json
             saved['timestamps'][key] = time.time()
         return saved['metadata'].get(key)
     return wrapper


### PR DESCRIPTION
I've done some preliminary work to make the starter pack build on macOS.

### macOS specific changes

- I updated `components.yml` to include some macOS-specific paths.
  - Notably, I disabled Armok Vision, because the author has [deliberately not published](https://github.com/JapaMala/armok-vision/releases/tag/v0.19.1) a Mac version for v0.19.1.

- I added the ability to extract .dmg files, which was needed for Legends Browser.
  - But I had to add a hack, because it otherwise wants to strip out the prefix `Legends Browser.app/` when copying files.

- I added support for extracting zip files and preserving the UNIX file mode, since ZipFile isn't aware of it.

- I tried to preserve symbolic links when copying files around, because macOS .app bundles often have symlinks that point to relative files.

### General bug fixes

- I fixed the metadata caching system, which was causing a huge startup performance hit. Now as long as you re-run the program within 30 minutes, no new metadata will be fetched.

- I removed concurrency from `extract.py`, because it was hiding error messages. The entire thing runs in about 15s on my laptop, and considering that this tool is only run once in a while, it does not seem worth the hassle for concurrency.
  - I wrote a simple `TaskQueue` which pops tasks off in dependency order, and catches dependency cycles.
  - If it is added back, it should definitely be done in such a way that it can be turned off without changing the behavior significantly.

### Other changes

- I added a `requirements.txt` for quickly installing required modules in a virtual environment.

- I replaced "OSX" with "macOS" wherever it was displayed to the user. (The product name was never written "OSX".) Internally, the `osx` identifier is still used, because it was a breaking change.

### Remaining issues

- [ ] The final (I assume) compression step fails because the SDL frameworks inside Dwarf Fortress contain symlinks with nonexistent targets.
  - Python's ZipFile doesn't really know how to deal with symlinks, so probably this should be done by invoking `zip` or another command line tool.
  - Still, the "Starter Pack Launcher (PyLNP).app" can be launched from the `build/` directory and used.

### How I've tested it

- Barely at all. I hope the community will be able to tell me what they expect to work, and what actually works.

- The Launcher app runs.

- The utilities can all be launched from the Launcher's Utilities panel.

- The "Play Dwarf Fortress!" button launches the game with some customized graphics.