### PR TITLE
Merge macOS compatibility updates from rgov/starter-pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ target/
 # Operating System Files
 # =========================
 
-# OSX
+# macOS
 # =========================
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -38,11 +38,8 @@ For anyone using these tools to assemble their own pack:
   set up and configured via these files, which are also commented.
 
 - You will need Python 3.5+, as I make extensive use of several
-  new features.  You will also need the `requests` and `pyaml`
-  libraries (both can be installed with `pip`).
-
-  Optional dependencies to unpack exotic archive types may be
-  added in future, but will not be required.
+  new features.  Dependencies can be installed with
+  `pip install -r requirements.txt`.
 
 - Many items in the provided config will only work on Windows
   (or when building for windows on another OS; tested on Debian).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See the [hourly build log here](http://peridexiserrant.neocities.org/starter-pac
 There is *no support* for using this tool - it is designed for my own use,
 and released in the hope that others might find it useful.
 Bug reports are most welcome; feature requests are not
-(missing OS support is considered a bug - it should work on Windows, OSX, and Linux).
+(missing OS support is considered a bug - it should work on Windows, macOS, and Linux).
 
 **What it does:**
 
@@ -46,7 +46,7 @@ For anyone using these tools to assemble their own pack:
 
 - Many items in the provided config will only work on Windows
   (or when building for windows on another OS; tested on Debian).
-  If you are interested in helping support OSX or Linux, please
+  If you are interested in helping support macOS or Linux, please
   get in touch with my handle at gmail.
 
 

--- a/components.yml
+++ b/components.yml
@@ -144,6 +144,7 @@ utilities:
         manifest:
             tooltip: A Sound+Music engine for DF - it reads the gamelog, and plays appropriate sounds and seasonal music.
             linux_exe: soundSense.sh
+            osx_exe: soundSense.sh
     World Viewer:
         requires_os: win
         bay12: 128932

--- a/components.yml
+++ b/components.yml
@@ -63,6 +63,7 @@ files:
         install_after: Quickfort
 utilities:
     Armok Vision:
+        requires_os: win linux
         bay12: 146473
         ident: JapaMala/armok-vision
         needs_dfhack: True

--- a/components.yml
+++ b/components.yml
@@ -26,6 +26,9 @@ files:
         os-linux:
             extract_to: |
                 PyLNP:build/starter-pack-launcher
+        os-osx:
+            extract_to: |
+                PyLNP.app:build/Starter Pack Launcher (PyLNP).app
     Stocksettings presets:
         bay12: 146213
         ident: 10170
@@ -43,6 +46,9 @@ files:
             extract_to: |
                 {DFHACK_VER}/mousequery.plug.so:plugins/
                 {DFHACK_VER}/twbt.plug.so:plugins/
+        os-osx:
+            extract_to: |
+                {DFHACK_VER}/twbt.plug.dylib:plugins/
         needs_dfhack: True
         install_after: DFHack
     Quickfort_64:

--- a/components.yml
+++ b/components.yml
@@ -108,6 +108,7 @@ utilities:
         ident: robertjanetzko/LegendsBrowser
         manifest:
             tooltip: An in-browser legends utility, available for all operating systems.
+            osx_exe: Legends Browser.app/Contents/MacOS/JavaAppLauncher
     Legends Viewer:
         requires_os: win
         bay12: 154617

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyyaml==3.12
+pyyaml==3.13
 rarfile==3.0
 requests==2.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml==3.12
+requests==2.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml==3.12
+rarfile==3.0
 requests==2.19.1

--- a/starterpack/build.py
+++ b/starterpack/build.py
@@ -237,7 +237,8 @@ def create_utilities():
         if paths.HOST_OS != 'win':
             with open(paths.utilities(util.name, 'manifest.json')) as f:
                 exe = json.load(f)[paths.HOST_OS + '_exe']
-            os.chmod(exe, 0o110 | os.stat(exe).st_mode)
+            path = paths.utilities(util.name, exe)
+            os.chmod(path, 0o110 | os.stat(path).st_mode)
 
 
 # Configure graphics packs

--- a/starterpack/build.py
+++ b/starterpack/build.py
@@ -191,12 +191,12 @@ def _therapist_ini():
 
 
 def _exes_for(util):
-    """Find the best available match for Windows and OSX utilities."""
+    """Find the best available match for Windows and macOS utilities."""
     win_exe, osx_exe, linux_exe = '', '', ''
     for _, dirs, files in os.walk(paths.utilities(util.name)):
         # Windows: first .exe found, first .bat otherwise
         # Linux: first .jar found, otherwise .sh
-        # OSX: as for linux, but a .app directory wins
+        # macOS: as for linux, but a .app directory wins
         for f in files:
             if win_exe and osx_exe and linux_exe:
                 break

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -64,7 +64,7 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
 
     Involves a lot of shelling out, as Python's `tarfile` cannot open
     the .tar.bz2 archived DF releases (complicated header issue).
-    OSX disk images (.dmg) are also unsupported by Python.
+    macOS disk images (.dmg) are also unsupported by Python.
     """
     if filename.endswith('.exe') and paths.HOST_OS == 'win' \
             or filename.endswith('.jar'):
@@ -96,7 +96,7 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
 def unpack_anything(filename, tmpdir):
     """Extract practically any archive format from src file to dest dir."""
     if filename.endswith('.dmg') and paths.HOST_OS == 'osx':
-        # TODO:  support .dmg extraction via shell on OSX
+        # TODO:  support .dmg extraction via shell on macOS
         raise NotImplementedError(
             'TODO: mount .dmg, copy contents to tmpdir, unmount')
     elif zipfile.is_zipfile(filename):

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -169,6 +169,10 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
         files = [os.path.join(root, f)
                  for root, _, files in os.walk(tmpdir) for f in files]
         prefix = os.path.commonpath(files) if len(files) > 1 else ''
+        # BAD HACK: It's an unsafe assumption (made above) that the common
+        # path should always be stripped.
+        if filename.endswith('.dmg') and 'Legends Browser' in target_dir:
+            prefix = ''
         if target_dir:
             copy_tree(os.path.join(tmpdir, prefix), target_dir,
                       preserve_symlinks=True)
@@ -246,7 +250,6 @@ def unpack_anything(filename, tmpdir):
 
 def extract_comp(comp):
     """Extracts a single component."""
-    print('Extracting', comp.name)
     if ':' not in comp.extract_to:
         # first part of extract_to is paths method, remainder is args
         dest, *details = comp.extract_to.split('/')

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -22,15 +22,14 @@ class TaskQueue:
     def __init__(self):
         self.tasks = {}
 
-    def add(self, name, value, prereqs=None):
-        self.tasks[name] = (value, prereqs or [])
+    def add(self, name, prereqs=None):
+        self.tasks[name] = (prereqs or [])
 
     def pop(self):
-        """Pops the next executable task off the queue and returns it."""
-        for name, (value, prereqs) in self.tasks.items():
+        for name, prereqs in self.tasks.items():
             if len(prereqs) == 0:
                 self.remove(name)
-                return value
+                return name
         # Nothing found with no pending prerequisites; maybe there's a circular
         # reference?
         if len(self.tasks) == 0:
@@ -38,27 +37,17 @@ class TaskQueue:
         raise RuntimeError('circular dependencies detected')
 
     def remove(self, name):
-        """Removes a task, and removes it as a dependency of other tasks."""
         del self.tasks[name]
-        for _, prereqs in self.tasks.values():
+        for prereqs in self.tasks.values():
             try:
                 prereqs.remove(name)
             except ValueError:
                 continue
-
-    def _check(self):
-        """Tests that every task is well-defined."""
-        for name, (_, prereqs) in self.tasks.items():
-            for prereq in prereqs:
-                if prereq not in self.tasks:
-                    raise ValueError('Task "%s" depends on missing task "%s"' %
-                                     (name, prereq))
-
+    
     def __iter__(self):
         """Allows iterating over queued tasks, which empties the queue."""
-        self._check()
         return self
-
+    
     def __next__(self):
         try:
             return self.pop()
@@ -111,7 +100,7 @@ def _copyfile(src, dest, zipinfo=None):
             mode = UnixAwareZipFile.get_mode(zipinfo)
             if mode != 0:
                 try:
-                    os.chmod(dest, mode)
+                    chmod(dest, mode)
                 except OSError:
                     print('Failed to correct mode of', targetpath)
                     raise
@@ -128,6 +117,7 @@ def unzip_to(filename, target_dir=None, path_pairs=None):
     In 'path_pairs' mode, the argument should be a sequence of paths.
     The file at the first path within the zip is written at the second path.
     """
+    print('unzip_to', filename, target_dir, path_pairs)
     assert bool(target_dir) != bool(path_pairs), 'Choose one unzip mode!'
     out = target_dir or os.path.commonpath([p[1] for p in path_pairs])
     print('{:28}  ->  {}'.format(os.path.basename(filename)[:28],
@@ -269,16 +259,9 @@ def extract_comp(comp):
 def extract_everything():
     """Extract every component, respecting order requirements."""
     queue = TaskQueue()
-    def enqueue_comp(comp):
-        after = [ comp.install_after ] if comp.install_after else []
-        queue.add(comp.name, comp, prereqs=after)
-
     for comp in component.ALL.values():
-        enqueue_comp(comp)
-    for path in ('curr_baseline', 'graphics/ASCII'):
-        comp = component.ALL['Dwarf Fortress']._replace(name=path,
-                                                        extract_to=path)
-        enqueue_comp(comp)
+        after = [ comp.install_after ] if comp.install_after else []
+        queue.add(comp, prereqs=after)
     for comp in queue:
         extract_comp(comp)
 

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -4,7 +4,6 @@ This module is about as generic as it can usefully be, pushing the special
 cases back into build.py
 """
 
-import concurrent.futures
 from distutils.dir_util import copy_tree
 import os
 import shutil
@@ -17,6 +16,43 @@ import zipfile
 
 from . import component
 from . import paths
+
+
+class TaskQueue:
+    def __init__(self):
+        self.tasks = {}
+
+    def add(self, name, prereqs=None):
+        self.tasks[name] = (prereqs or [])
+
+    def pop(self):
+        for name, prereqs in self.tasks.items():
+            if len(prereqs) == 0:
+                self.remove(name)
+                return name
+        # Nothing found with no pending prerequisites; maybe there's a circular
+        # reference?
+        if len(self.tasks) == 0:
+            raise IndexError('pop from empty queue')
+        raise RuntimeError('circular dependencies detected')
+
+    def remove(self, name):
+        del self.tasks[name]
+        for prereqs in self.tasks.values():
+            try:
+                prereqs.remove(name)
+            except ValueError:
+                continue
+    
+    def __iter__(self):
+        """Allows iterating over queued tasks, which empties the queue."""
+        return self
+    
+    def __next__(self):
+        try:
+            return self.pop()
+        except IndexError:
+            raise StopIteration
 
 
 class UnixAwareZipFile(zipfile.ZipFile):
@@ -54,7 +90,7 @@ def _copyfile(src, dest, zipinfo=None):
         if os.path.isfile(src):
             shutil.copy2(src, dest)
         elif os.path.isdir(src):
-            copy_tree(src, dest)
+            copy_tree(src, dest, preserve_symlinks=True)
         else:
             raise IOError('Unexpected file type for %s', src)
     elif isinstance(src, zipfile.ZipExtFile):
@@ -81,6 +117,7 @@ def unzip_to(filename, target_dir=None, path_pairs=None):
     In 'path_pairs' mode, the argument should be a sequence of paths.
     The file at the first path within the zip is written at the second path.
     """
+    print('unzip_to', filename, target_dir, path_pairs)
     assert bool(target_dir) != bool(path_pairs), 'Choose one unzip mode!'
     out = target_dir or os.path.commonpath([p[1] for p in path_pairs])
     print('{:28}  ->  {}'.format(os.path.basename(filename)[:28],
@@ -123,7 +160,8 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
                  for root, _, files in os.walk(tmpdir) for f in files]
         prefix = os.path.commonpath(files) if len(files) > 1 else ''
         if target_dir:
-            copy_tree(os.path.join(tmpdir, prefix), target_dir)
+            copy_tree(os.path.join(tmpdir, prefix), target_dir,
+                      preserve_symlinks=True)
         else:
             for inpath, outpath in path_pairs:
                 if outpath.endswith('/'):
@@ -188,63 +226,33 @@ def unpack_anything(filename, tmpdir):
     return False
 
 
-def extract_comp(pool, comp):
-    """Return args with which comp can be sent to the executor."""
+def extract_comp(comp):
+    """Extracts a single component."""
+    print('Extracting', comp.name)
     if ':' not in comp.extract_to:
         # first part of extract_to is paths method, remainder is args
         dest, *details = comp.extract_to.split('/')
-        return pool.submit(unzip_to, comp.path, getattr(paths, dest)(*details))
+        return unzip_to(comp.path, target_dir=getattr(paths, dest)(*details))
     # else using the path_pairs option; extract pairs from string
     pairs = []
-    for pair in comp.extract_to.strip().split('\n'):
-        src, to = pair.split(':')
+    for pair in comp.extract_to.strip().splitlines():
+        src, _, to = pair.partition(':')
         dest, *details = to.split('/')
         # Note: can add format variables here as needed
         if '{DFHACK_VER}' in src:
             src = src.format(DFHACK_VER=component.ALL['DFHack'].version)
-        pairs.append([src, getattr(paths, dest)(*details)])
-    return pool.submit(unzip_to, comp.path, None, pairs)
+        pairs.append((src, getattr(paths, dest)(*details)))
+    return unzip_to(comp.path, path_pairs=pairs)
 
 
 def extract_everything():
-    """Extract everything in components.yml, respecting order requirements."""
-    def q_key(comp):
-        """Decide extract priority by pointer-chase depth, filesize in ties."""
-        after = {c.install_after: c.name for c in component.ALL.values()}
-        name, seen = comp.name, []
-        while name in after:
-            seen.append(name)
-            name = after.get(name)
-            if name in seen:
-                raise ValueError('Cyclic "install_after" config detected: ' +
-                                 ' -> '.join(seen + [name]))
-        return len(seen), os.path.getsize(comp.path)
-
-    queue = list(component.ALL.values()) + [
-        component.ALL['Dwarf Fortress']._replace(name=path, extract_to=path)
-        for path in ('curr_baseline', 'graphics/ASCII')]
-    queue.sort(key=q_key, reverse=True)
-    with concurrent.futures.ProcessPoolExecutor(8) as pool:
-        futures = dict()
-        while queue:
-            while sum(f.running() for f in futures.values()) < 8:
-                for idx, comp in enumerate(queue):
-                    aft = futures.get(comp.install_after)
-                    # Even if it's highest-priority, wait for parent job(s)
-                    if aft is None or aft.done():
-                        futures[comp.name] = extract_comp(pool, queue.pop(idx))
-                        break  # reset index or we might pop the wrong item
-                else:
-                    break  # if there was nothing eligible to extract, sleep
-            time.sleep(0.01)
-    failed = [k for k, v in futures.items() if v.exception() is not None]
-    for key in failed:
-        comp = component.ALL.pop(key, None)
-        for lst in (component.FILES, component.GRAPHICS, component.UTILITIES):
-            if comp in lst:
-                lst.remove(comp)
-    if failed:
-        print('ERROR:  Could not extract: ' + ', '.join(failed))
+    """Extract every component, respecting order requirements."""
+    queue = TaskQueue()
+    for comp in component.ALL.values():
+        after = [ comp.install_after ] if comp.install_after else []
+        queue.add(comp, prereqs=after)
+    for comp in queue:
+        extract_comp(comp)
 
 
 def add_lnp_dirs():

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -163,7 +163,7 @@ def extract_comp(pool, comp):
         return pool.submit(unzip_to, comp.path, getattr(paths, dest)(*details))
     # else using the path_pairs option; extract pairs from string
     pairs = []
-    for pair in comp.extract_to.strip().split('\n'):
+    for pair in comp.extract_to.strip().splitlines():
         src, to = pair.split(':')
         dest, *details = to.split('/')
         # Note: can add format variables here as needed

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -93,12 +93,21 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
     return True
 
 
+def unpack_dmg(filename, dest):
+    """Extract a .dmg disk image on macOS into the dest dir."""
+    assert filename.endswith('.dmg') and paths.HOST_OS == 'osx'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(['hdiutil', 'attach', '-quiet', '-readonly',
+                               '-nobrowse', '-mountpoint', tmpdir, filename])
+        copy_tree(tmpdir, dest)
+        subprocess.check_call(['hdiutil', 'detach', '-quiet', tmpdir])
+
+
 def unpack_anything(filename, tmpdir):
     """Extract practically any archive format from src file to dest dir."""
     if filename.endswith('.dmg') and paths.HOST_OS == 'osx':
-        # TODO:  support .dmg extraction via shell on macOS
-        raise NotImplementedError(
-            'TODO: mount .dmg, copy contents to tmpdir, unmount')
+        unpack_dmg(filename, tmpdir)
+        return True
     elif zipfile.is_zipfile(filename):
         # Uses fast version above; handled here for completeness
         zipfile.ZipFile(filename).extractall(tmpdir)

--- a/starterpack/extract.py
+++ b/starterpack/extract.py
@@ -19,57 +19,14 @@ from . import component
 from . import paths
 
 
-class UnixAwareZipFile(zipfile.ZipFile):
-    """A ZipFile subclass aware of how to extract UNIX file permissions."""
-    @staticmethod
-    def get_mode(info):
-        """Returns the file mode that should be restored, or 0 if unknown."""
-        # Values below are from the "version made by" documentation at
-        # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
-        unix, macos = 3, 19
-        if info.create_system in (unix, macos):
-            return (info.external_attr >> 16) & 0o777
-        return 0
-
-    def _extract_member(self, member, targetpath, pwd):
-        # Based on internal implementation details of ZipFile, based on
-        # https://github.com/python/cpython/blob/3.7/Lib/zipfile.py
-        if not isinstance(member, zipfile.ZipInfo):
-            member = self.getinfo(member)
-        targetpath = super()._extract_member(member, targetpath, pwd)
-        mode = UnixAwareZipFile.get_mode(member)
-        if mode != 0:
-            try:
-                os.chmod(targetpath, mode)
-            except OSError:
-                print('Failed to correct mode of', targetpath)
-                raise
-        return targetpath
-
-
-def _copyfile(src, dest, zipinfo=None):
+def _copyfile(src, dest):
     """Copy the source file path or object to the dest path, creating dirs."""
     os.makedirs(os.path.dirname(dest), exist_ok=True)
     if isinstance(src, str):
-        if os.path.isfile(src):
-            shutil.copy2(src, dest)
-        elif os.path.isdir(src):
-            copy_tree(src, dest)
-        else:
-            raise IOError('Unexpected file type for %s', src)
-    elif isinstance(src, zipfile.ZipExtFile):
+        shutil.copy2(src, dest)
+    else:
         with open(dest, 'wb') as out:
             shutil.copyfileobj(src, out)
-        if zipinfo:
-            mode = UnixAwareZipFile.get_mode(zipinfo)
-            if mode != 0:
-                try:
-                    chmod(dest, mode)
-                except OSError:
-                    print('Failed to correct mode of', targetpath)
-                    raise
-    else:
-        raise NotImplementedException('Unexpected source type')
 
 
 def unzip_to(filename, target_dir=None, path_pairs=None):
@@ -95,9 +52,9 @@ def unzip_to(filename, target_dir=None, path_pairs=None):
         files = dict(a for a in zip(zf.namelist(), zf.infolist())
                      if not a[0].endswith('/'))
         prefix = os.path.commonpath(list(files)) if len(files) > 1 else ''
-        for name, info in files.items():
+        for name in files:
             out = os.path.join(target_dir, os.path.relpath(name, prefix))
-            _copyfile(zf.open(info), out, zipinfo=info)
+            _copyfile(zf.open(files[name]), out)
 
 
 def nonzip_extract(filename, target_dir=None, path_pairs=None):
@@ -132,7 +89,7 @@ def nonzip_extract(filename, target_dir=None, path_pairs=None):
             for inpath, outpath in path_pairs:
                 if outpath.endswith('/'):
                     outpath += os.path.basename(inpath)
-                if os.path.exists(os.path.join(tmpdir, prefix, inpath)):
+                if os.path.isfile(os.path.join(tmpdir, prefix, inpath)):
                     _copyfile(os.path.join(tmpdir, prefix, inpath), outpath)
                 else:
                     print('WARNING:  "{}" not found in "{}"'.format(
@@ -164,10 +121,8 @@ def unpack_anything(filename, tmpdir):
         unpack_dmg(filename, tmpdir)
         return True
     elif zipfile.is_zipfile(filename):
-        # zip files *can* include information about UNIX file modes, but Python
-        # does not extract them. Skip using zipfile and just shell out to the
-        # command line.
-        UnixAwareZipFile(filename).extractall(tmpdir)
+        # Uses fast version above; handled here for completeness
+        zipfile.ZipFile(filename).extractall(tmpdir)
         return True
     elif any(filename.endswith('.tar.' + ext) for ext in ('bz2', 'xz', 'gz'))\
             or tarfile.is_tarfile(filename):

--- a/starterpack/metadata_api.py
+++ b/starterpack/metadata_api.py
@@ -26,7 +26,7 @@ def get_auth():
     return None
 
 
-def cache(method=lambda *_: None, *, saved={}, dump=False):
+def cache(method=lambda *_: None, *, saved={}, dump=False, expiration=30*60):
     """A caching decorator.
 
     Reads cache from local file if cache is empty.
@@ -37,10 +37,11 @@ def cache(method=lambda *_: None, *, saved={}, dump=False):
         try:
             with open('_cached.yml') as f:
                 saved.update(yaml.load(f))
+                print('Loaded metadata from cache file')
         except IOError:
-            print('Downloading metadata for components...\n')
             saved.update({'metadata': {}, 'timestamps': {}})
     elif dump:
+        print('Saving metadata to cache file')
         with open('_cached.yml', 'w') as f:
             yaml.dump(saved, f, indent=4)
 
@@ -50,11 +51,13 @@ def cache(method=lambda *_: None, *, saved={}, dump=False):
             key = (not paths.ARGS.stable, ident)
             args = (self, ident, saved['timestamps'].get(key, 0),
                     saved['metadata'].get(ident))
-        if (time.time() - saved['timestamps'].get(key, 0)) > 30*60:
+        if (time.time() - saved['timestamps'].get(key, 0)) > expiration:
+            print('Refreshing metadata for package', ident)
             new_json = method(*args)
+            # We take a return value of None to mean that it hasn't been updated
             if new_json is not None:
                 saved['metadata'][key] = new_json
-                saved['timestamps'][key] = time.time()
+            saved['timestamps'][key] = time.time()
         return saved['metadata'].get(key)
     return wrapper
 

--- a/starterpack/metadata_api.py
+++ b/starterpack/metadata_api.py
@@ -50,13 +50,13 @@ def cache(method=lambda *_: None, *, saved={}, dump=False, expiration=30*60):
         if isinstance(self, GitHubAssetMetadata):
             key = (not paths.ARGS.stable, ident)
             args = (self, ident, saved['timestamps'].get(key, 0),
-                    saved['metadata'].get(ident))
+                    saved['metadata'].get(key))
         if (time.time() - saved['timestamps'].get(key, 0)) > expiration:
             print('Refreshing metadata for package', ident)
             new_json = method(*args)
-            # We take a return value of None to mean that it hasn't been updated
-            if new_json is not None:
-                saved['metadata'][key] = new_json
+            if new_json is None:
+                raise RuntimeError('Failed to get metadata for', ident)
+            saved['metadata'][key] = new_json
             saved['timestamps'][key] = time.time()
         return saved['metadata'].get(key)
     return wrapper


### PR DESCRIPTION
Merge the key macOS compatibility updates from rgov/starter-pack, while reverting the breaking TaskQueue  (f004f65a8b8ce8312a7e2eed0d7fcb8d5578709c & e38f4030bd834eb8266539a800de98efdad68c34) and Unix/POSIX file mode unzipping (1958aac09c047df02b629ffe165426f5a3a3708e).

Drive-by bugfixes for newlines and for unzipping were recommitted separately (1c84665f3132e5f92d8a666276f4ffec2708e259 & 62f00582a031b1aee3f26e8671ab943a1b46a0e9).

For now, in the absence of POSIX file mode unzipping, a package builder can properly reextract PyLNP after running `main.py` with:

```sh
rm -rf 'build/Starter Pack Launcher (PyLNP).app'
unzip components/PyLNP_0.13b-OSX.zip -x PyLNP.json -d build  # change to latest zip
mv build/PyLNP.app 'build/Starter Pack Launcher (PyLNP).app'
```

Of course the final distribution zipping still fails, but that's OK since a macOS distribution will be packaged by some other means anyway (e.g. a dmg).